### PR TITLE
chore: tidy Go module dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/kurehajime/flagstone
 
 go 1.13
 
-require (
-	github.com/icza/gowut v1.4.0
-	github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d // indirect
-)
+require github.com/icza/gowut v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 github.com/icza/gowut v1.4.0 h1:OwUKBXP20Iw3EgghXznRyuohMM5hG9zID9bU1n+a6+U=
 github.com/icza/gowut v1.4.0/go.mod h1:0bLWFdhY/FxwCx2nDrezL87kfFgPfwZn9GytsrUPM8U=
-github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d h1:cVtBfNW5XTHiKQe7jDaDBSh/EVM4XLPutLAGboIXuM0=
-github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2viExyCEfeWGU259JnaQ34Inuec4R38JCyBx2edgD0=


### PR DESCRIPTION
## Summary
- ran go mod tidy with Go 1.24 to clean up stale module references
- removed unused indirect dependency github.com/kami-zh/go-capturer from go.mod/go.sum

## Verification
- go test ./...
